### PR TITLE
fix error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+_replicator
+_users
+node_modules
+pouch__all_dbs__
+chat
+config.json
+log.txt

--- a/server/server.js
+++ b/server/server.js
@@ -13,7 +13,7 @@ db.info().then(function (info) {
 process.on('uncaughtException', function (err) {
     console.log(err);
 });
-
+db.setMaxListeners(10);
 db.changes({
     since: 'now',
     live: true,


### PR DESCRIPTION
(node) warning: possible EventEmitter memory leak detected. 11 chat listeners added. Use emitter.setMaxListeners() to increase limit. [docs](https://nodejs.org/docs/latest/api/events.html#events_emitter_setmaxlisteners_n)
